### PR TITLE
Integrate additional content into scrollytelling

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -15,11 +15,11 @@ export default function AboutPage() {
       <Menu isOpen={isMenuOpen} onMenuClose={handleMenuClose} />
       <main className="page-content pt-24 sm:pt-32 px-6 sm:px-12 md:px-24 lg:px-36 xl:px-0">
         <div className="max-w-4xl xl:max-w-screen-xl mx-auto">
-          <ScrollytellingSection />
-          <section id="additional-content" className="mt-16 space-y-8">
-            <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold">
-              The Future of Agency Work is Here
-            </h2>
+          <ScrollytellingSection>
+            <section id="additional-content" className="mt-16 space-y-8">
+              <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold">
+                The Future of Agency Work is Here
+              </h2>
             <p className="text-xl sm:text-2xl md:text-3xl">
               Our founding team brings 23 years of combined experience from BBDO,
               Leo Burnett, and Wieden+Kennedy. We&apos;ve worked on campaigns that generated
@@ -73,7 +73,8 @@ export default function AboutPage() {
               processes. No 18-month commitments. Just better work, delivered faster,
               for clients who want to move at the speed of business, not bureaucracy.
             </p>
-          </section>
+            </section>
+          </ScrollytellingSection>
         </div>
       </main>
     </div>

--- a/src/components/ScrollytellingSection.tsx
+++ b/src/components/ScrollytellingSection.tsx
@@ -24,7 +24,11 @@ const LINES: string[] = [
   "Now let's make yours."
 ];
 
-export default function ScrollytellingSection() {
+export default function ScrollytellingSection({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const sectionRef = useRef<HTMLElement | null>(null);
   const panelRefs  = useRef<HTMLDivElement[]>([]);
   const tlRef      = useRef<gsap.core.Timeline | null>(null);
@@ -55,6 +59,7 @@ export default function ScrollytellingSection() {
         pin: true,
         scrub: true,
         anticipatePin: 1,
+        onLeave: self => self.kill(),
         snap: {
           snapTo: step,
           duration: { min: 0.05, max: 0.1 },
@@ -75,12 +80,6 @@ export default function ScrollytellingSection() {
       );
     });
 
-    tl.to(
-      panels[panels.length - 1],
-      { autoAlpha: 0, duration: step / 2 },
-      1 - step / 2
-    );
-
     return () => {
       tl.kill();
       ScrollTrigger.getAll().forEach(t => t.kill());
@@ -88,8 +87,9 @@ export default function ScrollytellingSection() {
   }, []);
 
   const handleSkip = () => {
-    tlRef.current?.scrollTrigger?.disable();
-    tlRef.current?.progress(1);
+    const tl = tlRef.current;
+    tl?.scrollTrigger?.kill();
+    tl?.progress(1);
     document
       .getElementById('additional-content')
       ?.scrollIntoView({ behavior: 'smooth' });
@@ -109,6 +109,9 @@ export default function ScrollytellingSection() {
             </p>
           </div>
         ))}
+        <div ref={addPanel} className="absolute inset-0 flex items-center justify-center">
+          {children}
+        </div>
         <button
           onClick={handleSkip}
           className="absolute bottom-4 right-4 text-sm text-black/60 hover:text-black transition-colors"


### PR DESCRIPTION
## Summary
- pass children through `ScrollytellingSection` so the extra content becomes the last panel
- animate text panels then release the ScrollTrigger when scrolling past the section
- update About page to place the "additional-content" section inside `ScrollytellingSection`
- adjust skip button to kill the ScrollTrigger before jumping

## Testing
- `npm run lint`
